### PR TITLE
SUBS 1101 sheet mapping dataformat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '1.6.1-SNAPSHOT'
+version '1.6.2-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/uk/ac/ebi/subs/repository/model/sheets/Row.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/model/sheets/Row.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.subs.repository.model.sheets;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NonNull;
 import org.springframework.util.Assert;
@@ -14,6 +16,13 @@ public class Row {
     @NonNull
     private List<String> cells;
     private boolean ignored;
+
+    @JsonRawValue
+    private String document;
+
+    private void setDocument(JsonNode jsonNode){
+        this.document = jsonNode.toString();
+    }
 
     public Row() {
         cells = new LinkedList<>();

--- a/src/main/java/uk/ac/ebi/subs/repository/model/templates/FieldCapture.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/model/templates/FieldCapture.java
@@ -35,8 +35,9 @@ public class FieldCapture implements Capture {
     public int capture(int position, List<String> headers, List<String> values, JSONObject document) {
         String value = values.get(position);
 
-        fieldType.addValueToDocument(fieldName,value,document);
-
+        if (value != null) {
+            fieldType.addValueToDocument(fieldName, value, document);
+        }
         return ++position;
     }
 

--- a/src/main/java/uk/ac/ebi/subs/repository/model/templates/JsonFieldType.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/model/templates/JsonFieldType.java
@@ -2,6 +2,10 @@ package uk.ac.ebi.subs.repository.model.templates;
 
 import org.json.JSONObject;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by Dave on 18/10/2017.
  */
@@ -12,41 +16,37 @@ public enum JsonFieldType {
     FloatNumber,
     Boolean;
 
-    public void addValueToDocument(String fieldName, String value, JSONObject document){
-        switch (this){
+
+
+    public void addValueToDocument(String fieldName, String value, JSONObject document) throws NumberFormatException {
+          switch (this) {
             case String:
-                document.put(fieldName,value);
+                document.put(fieldName, value);
                 break;
             case IntegerNumber:
-                try {
-                    long longVal = Long.parseLong(value);
-                    document.put(fieldName,longVal);
-                }
-                catch (NumberFormatException e){
-                    document.put(fieldName,value);
-                }
+                long longVal = Long.parseLong(value);
+                document.put(fieldName, longVal);
                 break;
             case FloatNumber:
-                try {
-                    double doubleVal = Double.parseDouble(value);
-                    document.put(fieldName,doubleVal);
-                }
-                catch (NumberFormatException e){
-                    document.put(fieldName,value);
-                }
+                double doubleVal = Double.parseDouble(value);
+                document.put(fieldName, doubleVal);
                 break;
             case Boolean:
-                try {
-                    boolean boolVal = java.lang.Boolean.parseBoolean(value);
-                    document.put(fieldName,boolVal);
-                }
-                catch (NumberFormatException e){
-                    document.put(fieldName,value);
-                }
+                String lcValue = value.toLowerCase();
+                Boolean boolVal = booleanTextValues.get(lcValue);
+                document.put(fieldName, boolVal);
                 break;
             default:
-                throw new IllegalArgumentException("cannot add value for type: "+this.name());
+                throw new IllegalArgumentException("cannot add value for type: " + this.name());
         }
 
+    }
+
+    private static final Map<String,Boolean> booleanTextValues;
+    static {
+        Map<String,Boolean> map = new HashMap<>();
+        map.put("true", true);
+        map.put("false", false);
+        booleanTextValues = Collections.unmodifiableMap(map);
     }
 }


### PR DESCRIPTION
Allow number format exceptions to propagate during spreadsheet / template mapping, so we can validate for these problems. 