### PR TITLE
SUBS-1457 versions reverted back 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '2.8.2-SNAPSHOT'
+version '2.8.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile("uk.ac.ebi.subs:validator-common:2.10.2-SNAPSHOT")
+    compile("uk.ac.ebi.subs:validator-common:2.10.1-SNAPSHOT")
 
     compile ('org.atteo:evo-inflector:1.2.1') // better pluralisation
     compile("org.json:json:20160810")


### PR DESCRIPTION
Pull request with study data type changes to sample validation message envelope is now closed. The validator common version remains the same now. Hence reverting the subs repo version too. 