### PR TITLE
[SUBS-1705] Add AccessionIdRepository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.26.0-SNAPSHOT'
+version '2.27.0-SNAPSHOT'
 
 
 apply plugin: 'java'

--- a/src/main/java/uk/ac/ebi/subs/repository/model/accession/AccessionIdWrapper.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/model/accession/AccessionIdWrapper.java
@@ -1,0 +1,21 @@
+package uk.ac.ebi.subs.repository.model.accession;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+@Data
+@EqualsAndHashCode
+public class AccessionIdWrapper {
+
+    @Id
+    private String id;
+
+    private String submissionId;
+    private String bioStudiesAccessionId;
+    private List<String> bioSamplesAccessionIds;
+}

--- a/src/main/java/uk/ac/ebi/subs/repository/repos/AccessionIdRepository.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/repos/AccessionIdRepository.java
@@ -1,0 +1,11 @@
+package uk.ac.ebi.subs.repository.repos;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.ac.ebi.subs.repository.model.accession.AccessionIdWrapper;
+
+@Repository
+public interface AccessionIdRepository extends MongoRepository<AccessionIdWrapper, String> {
+
+    AccessionIdWrapper findBySubmissionId(String submissionId);
+}

--- a/src/test/java/uk/ac/ebi/subs/repository/AccessionIdRepositoryTest.java
+++ b/src/test/java/uk/ac/ebi/subs/repository/AccessionIdRepositoryTest.java
@@ -1,0 +1,60 @@
+package uk.ac.ebi.subs.repository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.ac.ebi.subs.repository.model.accession.AccessionIdWrapper;
+import uk.ac.ebi.subs.repository.repos.AccessionIdRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataMongoTest
+public class AccessionIdRepositoryTest {
+
+    @Autowired
+    private AccessionIdRepository accessionIdRepository;
+
+    private static final String SUBMISSION_ID = UUID.randomUUID().toString();
+    private static final String BIOSTUDIES_ACCESSIONID = "S-SUBS987654321";
+    private static final List<String> BIOSAMPLES_ACCESSIONIDS = new ArrayList<>();
+    private static final int NUMBER_OF_BIOSAMPLE_ACCESSIONIDS = 5;
+
+    @Before
+    public void setup() {
+        generateBiosamplesAccessionIds();
+        createAccessionIdWrapper();
+    }
+
+    @Test
+    public void whenAccessionIdsBySubmisionIDInRepoThenItReturnsThem() {
+        AccessionIdWrapper accessionIdWrapper = accessionIdRepository.findBySubmissionId(SUBMISSION_ID);
+
+        assertThat(accessionIdWrapper.getSubmissionId(), is(equalTo(SUBMISSION_ID)));
+    }
+
+    private void generateBiosamplesAccessionIds() {
+        for (int i = 0; i < NUMBER_OF_BIOSAMPLE_ACCESSIONIDS; i++) {
+            BIOSAMPLES_ACCESSIONIDS.add(UUID.randomUUID().toString());
+        }
+    }
+
+    private void createAccessionIdWrapper() {
+        AccessionIdWrapper accessionIdWrapper = new AccessionIdWrapper();
+        accessionIdWrapper.setId(UUID.randomUUID().toString());
+        accessionIdWrapper.setSubmissionId(SUBMISSION_ID);
+        accessionIdWrapper.setBioStudiesAccessionId(BIOSTUDIES_ACCESSIONID);
+        accessionIdWrapper.setBioSamplesAccessionIds(BIOSAMPLES_ACCESSIONIDS);
+
+        accessionIdRepository.save(accessionIdWrapper);
+    }
+}


### PR DESCRIPTION
Add a repository for storing the returned accession IDs from the archives. Initially it would only store IDs from BioStudies and BioSamples by submissionId. 
We can add other archives later when we would need them.