### PR TITLE
[SUBS-1771] Add an index to the submittableId field of ProcessingStatus entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.30.0-SNAPSHOT'
+version '2.30.1-SNAPSHOT'
 
 
 apply plugin: 'java'

--- a/src/main/java/uk/ac/ebi/subs/repository/model/ProcessingStatus.java
+++ b/src/main/java/uk/ac/ebi/subs/repository/model/ProcessingStatus.java
@@ -20,7 +20,8 @@ import java.util.Date;
 
 @CompoundIndexes({
         @CompoundIndex(background = true, name = "submissionId_submittableId", def = "{ 'submissionId': 1, 'submittableId': 1}"),
-        @CompoundIndex(background = true, name = "submissionId_status", def = "{ 'submissionId': 1, 'status': 1}")
+        @CompoundIndex(background = true, name = "submissionId_status", def = "{ 'submissionId': 1, 'status': 1}"),
+        @CompoundIndex(background = true, name = "submittableId", def = "{ 'submittableId': 1}")
 })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)


### PR DESCRIPTION
Changes:
- Add an index to the submittableId field of ProcessingStatus to speed up the findBy query